### PR TITLE
feat: Add additional status values for controller

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -454,7 +454,15 @@ sensor:
         case 0:
           id(cAmbientTemp).publish_state((x[1] << 8) | x[0]);
           id(vTcTemp1).publish_state((x[3] << 8) | x[2]);
-          id(cPowerIcon).publish_state(((x[5] << 8) | x[4]) - 1); // Values are 1, 2 and 3. Start with 0 so we can work with index
+         // POWER ICON VALIDIERUNG
+          {
+          int raw_power = (x[5] << 8) | x[4];
+          if (raw_power >= 1 && raw_power <= 3) {
+          id(cPowerIcon).publish_state(raw_power - 1);
+           } else {
+                 ESP_LOGW("ble_parse", "Ignore invalid Power value: %d", raw_power);
+                  }
+           } // Values are 1, 2 and 3. Start with 0 so we can work with index
           id(cControllerStatus).publish_state((x[7] << 8) | x[6]);
           id(cAirSlider).publish_state((x[9] << 8) | x[8]);
           break;


### PR DESCRIPTION
Add missing controller states 6,7 and 8.

I've identified some further states for the S-Thermatik NEO controller through testing and observation:

- State 6: No ignition - Triggered when the stove fails to reach the required temperature during ignition phase.
- State 7: Overheated - Safety state when the exhaust gas temperature is too high.
- State 8 Reducing glow - The final phase after 'Glowing' before returning to 'Standby'.

I've updated the lambda function in package.yaml to include these states. These additions provide a more complete status overview for users.